### PR TITLE
Add well-formedness test for assume/assert

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -526,6 +526,12 @@ int cbmc_parse_optionst::doit()
   if(set_properties())
     return CPROVER_EXIT_SET_PROPERTIES_FAILED;
 
+  if(cmdline.isset("validate-goto-model"))
+  {
+    const namespacet ns(goto_model.symbol_table);
+    goto_model.validate(ns, validation_modet::INVARIANT);
+  }
+
   return bmct::do_language_agnostic_bmc(
     path_strategy_chooser, options, goto_model, ui_message_handler);
 }
@@ -972,6 +978,9 @@ void cbmc_parse_optionst::help()
     " --xml-ui                     use XML-formatted output\n"
     " --xml-interface              bi-directional XML interface\n"
     " --json-ui                    use JSON-formatted output\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --validate-goto-model        enable additional well-formedness checks on the\n"
+    "                              goto program\n"
     HELP_GOTO_TRACE
     HELP_FLUSH
     " --verbosity #                verbosity level\n"

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -72,6 +72,7 @@ class optionst;
   OPT_FLUSH \
   "(localize-faults)(localize-faults-method):" \
   OPT_GOTO_TRACE \
+  "(validate-goto-model)" \
   "(claim):(show-claims)(floatbv)(all-claims)(all-properties)" // legacy, and will eventually disappear // NOLINT(whitespace/line_length)
 // clang-format on
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -406,6 +406,12 @@ int goto_analyzer_parse_optionst::doit()
   if(process_goto_program(options))
     return CPROVER_EXIT_INTERNAL_ERROR;
 
+  if(cmdline.isset("validate-goto-model"))
+  {
+    const namespacet ns(goto_model.symbol_table);
+    goto_model.validate(ns, validation_modet::INVARIANT);
+  }
+
   // show it?
   if(cmdline.isset("show-symbol-table"))
   {
@@ -875,6 +881,9 @@ void goto_analyzer_parse_optionst::help()
     HELP_GOTO_CHECK
     "\n"
     "Other options:\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --validate-goto-model        enable additional well-formedness checks on the\n"
+    "                              goto program\n"
     " --version                    show version and exit\n"
     HELP_FLUSH
     HELP_TIMESTAMP

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -148,6 +148,7 @@ class optionst;
   "(show)(verify)(simplify):" \
   "(location-sensitive)(concurrent)" \
   "(no-simplify-slicing)" \
+  "(validate-goto-model)" \
 // clang-format on
 
 class goto_analyzer_parse_optionst:

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -125,7 +125,28 @@ int goto_instrument_parse_optionst::doit()
 
     get_goto_program();
 
+    {
+      const bool b = cmdline.isset("validate-goto-binary");
+
+      if(b || cmdline.isset("validate-goto-model"))
+      {
+        const namespacet ns(goto_model.symbol_table);
+        goto_model.validate(ns, validation_modet::EXCEPTION);
+
+        if(b)
+        {
+          return CPROVER_EXIT_SUCCESS;
+        }
+      }
+    }
+
     instrument_goto_program();
+
+    if(cmdline.isset("validate-goto-model"))
+    {
+      const namespacet ns(goto_model.symbol_table);
+      goto_model.validate(ns, validation_modet::INVARIANT);
+    }
 
     {
       bool unwind_given=cmdline.isset("unwind");
@@ -1569,6 +1590,12 @@ void goto_instrument_parse_optionst::help()
     " --show-local-safe-pointers   show pointer expressions that are trivially dominated by a not-null check\n" // NOLINT(*)
     " --show-safe-dereferences     show pointer expressions that are trivially dominated by a not-null check\n" // NOLINT(*)
     "                              *and* used as a dereference operand\n" // NOLINT(*)
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --validate-goto-model        enable additional well-formedness checks on the\n"
+    "                              goto program\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --validate-goto-binary       check the well-formedness of the passed in goto\n"
+    "                              binary and then exit\n"
     "\n"
     "Safety checks:\n"
     " --no-assertions              ignore user assertions\n"

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -101,6 +101,8 @@ Author: Daniel Kroening, kroening@kroening.com
   OPT_GOTO_PROGRAM_STATS \
   "(show-local-safe-pointers)(show-safe-dereferences)" \
   OPT_REPLACE_CALLS \
+  "(validate-goto-binary)" \
+  "(validate-goto-model)" \
   // empty last line
 
 // clang-format on

--- a/src/goto-programs/goto_function.h
+++ b/src/goto-programs/goto_function.h
@@ -110,6 +110,16 @@ public:
     parameter_identifiers = std::move(other.parameter_identifiers);
     return *this;
   }
+
+  /// Check that the goto function is well-formed
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate(const namespacet &ns, const validation_modet vm) const
+  {
+    body.validate(ns, vm);
+    validate_type_full_pick(type, ns, vm);
+  }
 };
 
 void get_local_identifiers(const goto_functiont &, std::set<irep_idt> &dest);

--- a/src/goto-programs/goto_function.h
+++ b/src/goto-programs/goto_function.h
@@ -115,9 +115,10 @@ public:
   ///
   /// The validation mode indicates whether well-formedness check failures are
   /// reported via DATA_INVARIANT violations or exceptions.
-  void validate(const namespacet &ns, const validation_modet vm) const
+  void validate(const symbol_tablet &table, const validation_modet vm) const
   {
-    body.validate(ns, vm);
+    body.validate(table, vm);
+    namespacet ns(table);
     validate_type_full_pick(type, ns, vm);
   }
 };

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -118,6 +118,19 @@ public:
     for(const auto &fun : other.function_map)
       function_map[fun.first].copy_from(fun.second);
   }
+
+  /// Check that the goto functions are well-formed
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate(const namespacet &ns, const validation_modet vm) const
+  {
+    for(const auto &entry : function_map)
+    {
+      const goto_functiont &goto_function = entry.second;
+      goto_function.validate(ns, vm);
+    }
+  }
 };
 
 #define Forall_goto_functions(it, functions) \

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -123,12 +123,12 @@ public:
   ///
   /// The validation mode indicates whether well-formedness check failures are
   /// reported via DATA_INVARIANT violations or exceptions.
-  void validate(const namespacet &ns, const validation_modet vm) const
+  void validate(const symbol_tablet &table, const validation_modet vm) const
   {
     for(const auto &entry : function_map)
     {
       const goto_functiont &goto_function = entry.second;
-      goto_function.validate(ns, vm);
+      goto_function.validate(table, vm);
     }
   }
 };

--- a/src/goto-programs/goto_model.h
+++ b/src/goto-programs/goto_model.h
@@ -95,6 +95,16 @@ public:
     return goto_functions.function_map.find(id) !=
            goto_functions.function_map.end();
   }
+
+  /// Check that the goto model is well-formed
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate(const namespacet &ns, const validation_modet vm) const
+  {
+    goto_functions.validate(ns, vm);
+    symbol_table.validate();
+  }
 };
 
 /// Class providing the abstract GOTO model interface onto an unrelated

--- a/src/goto-programs/goto_model.h
+++ b/src/goto-programs/goto_model.h
@@ -102,7 +102,7 @@ public:
   /// reported via DATA_INVARIANT violations or exceptions.
   void validate(const namespacet &ns, const validation_modet vm) const
   {
-    goto_functions.validate(ns, vm);
+    goto_functions.validate(symbol_table, vm);
     symbol_table.validate();
   }
 };

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -769,14 +769,12 @@ void goto_programt::instructiont::validate(
       code.get_statement() == ID_function_call,
       "function call instruction should contain a call statement",
       source_location);
-    code.validate(ns, vm);
     break;
   case RETURN:
     DATA_CHECK_WITH_DIAGNOSTICS(
       code.get_statement() == ID_return,
       "return instruction should contain a return statement",
       source_location);
-    code.validate(ns, vm);
     break;
   default:
     break;

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -676,24 +676,21 @@ void goto_programt::instructiont::validate(
   validate_expr_full_pick(guard, ns, vm);
 
   auto evaluates_to_boolean = [](const exprt &e) -> bool {
-    //typecast to Boolean
+    if(e.type().id() != ID_bool)
+      return false;
+
     if(e.id() == ID_typecast)
       return e.type().id() == ID_bool;
 
     //Boolean constants
     if(e.id() == ID_true || e.id() == ID_false)
       return true;
-    if(e.id() == ID_constant && e.type().id() == ID_bool)
+    if(e.id() == ID_constant)
       return true;
 
     //Symbols
     if(e.id() == ID_symbol)
-    {
-      if(e.type().id() == ID_code) //function call
-        return to_code_type(e.type()).return_type().id() == ID_bool;
-      else //Boolean variable
-        return e.type().id() == ID_bool;
-    }
+      return true;
 
     //arithmetic relations
     if(e.id() == ID_equal || e.id() == ID_notequal)

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -755,12 +755,28 @@ void goto_programt::instructiont::validate(
     for(const auto &t : targets)
     {
       DATA_CHECK_WITH_DIAGNOSTICS(
-        t->is_target(), "goto target has to be a target", source_location);
+        t->is_target() && t->target_number != 0,
+        "goto target has to be a target",
+        source_location);
     }
     DATA_CHECK_WITH_DIAGNOSTICS(
       evaluates_to_boolean(guard),
       "goto with non-boolean condition\n" + guard.pretty(),
       source_location);
+    break;
+  case FUNCTION_CALL:
+    DATA_CHECK_WITH_DIAGNOSTICS(
+      code.get_statement() == ID_function_call,
+      "function call instruction should contain a call statement",
+      source_location);
+    code.validate(ns, vm);
+    break;
+  case RETURN:
+    DATA_CHECK_WITH_DIAGNOSTICS(
+      code.get_statement() == ID_return,
+      "return instruction should contain a return statement",
+      source_location);
+    code.validate(ns, vm);
     break;
   default:
     break;

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -736,6 +736,7 @@ void goto_programt::instructiont::validate(
       evaluates_to_boolean(guard),
       "assuming non-boolean condition\n" + guard.pretty(),
       source_location);
+    break;
   case ASSERT:
     DATA_CHECK_WITH_DIAGNOSTICS(
       targets.empty(),
@@ -745,6 +746,22 @@ void goto_programt::instructiont::validate(
       evaluates_to_boolean(guard),
       "asserting non-boolean condition\n" + guard.pretty(),
       source_location);
+    break;
+  case GOTO:
+    DATA_CHECK_WITH_DIAGNOSTICS(
+      has_target(),
+      "goto instruction expects at least one target",
+      source_location);
+    for(const auto &t : targets)
+    {
+      DATA_CHECK_WITH_DIAGNOSTICS(
+        t->is_target(), "goto target has to be a target", source_location);
+    }
+    DATA_CHECK_WITH_DIAGNOSTICS(
+      evaluates_to_boolean(guard),
+      "goto with non-boolean condition\n" + guard.pretty(),
+      source_location);
+    break;
   default:
     break;
   }

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -669,9 +669,10 @@ bool goto_programt::instructiont::equals(const instructiont &other) const
 }
 
 void goto_programt::instructiont::validate(
-  const namespacet &ns,
+  const symbol_tablet &table,
   const validation_modet vm) const
 {
+  namespacet ns(table);
   validate_code_full_pick(code, ns, vm);
   validate_expr_full_pick(guard, ns, vm);
 
@@ -776,6 +777,27 @@ void goto_programt::instructiont::validate(
       "return instruction should contain a return statement",
       source_location);
     break;
+  case DEAD:
+    DATA_CHECK_WITH_DIAGNOSTICS(
+      code.get_statement() == ID_dead,
+      "dead instructions should contain a dead statement",
+      source_location);
+    DATA_CHECK_WITH_DIAGNOSTICS(
+      table.has_symbol(to_code_dead(code).get_identifier()),
+      "removing unknown symbol: " +
+        id2string(to_code_dead(code).get_identifier()) + " from scope",
+      source_location);
+    break;
+  case DECL:
+    DATA_CHECK_WITH_DIAGNOSTICS(
+      code.get_statement() == ID_decl,
+      "declaration instructions should contain a declaration statement",
+      source_location);
+    DATA_CHECK_WITH_DIAGNOSTICS(
+      table.has_symbol(to_code_decl(code).get_identifier()),
+      "declaring unknown symbol: " +
+        id2string(to_code_decl(code).get_identifier()),
+      source_location);
   default:
     break;
   }

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -20,10 +20,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/invariant.h>
 #include <util/namespace.h>
-#include <util/symbol_table.h>
 #include <util/source_location.h>
-#include <util/std_expr.h>
 #include <util/std_code.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+#include <util/validate.h>
 
 /// The type of an instruction in a GOTO program.
 enum goto_program_instruction_typet
@@ -407,6 +408,19 @@ public:
     {
       validate_code_full_pick(code, ns, vm);
       validate_expr_full_pick(guard, ns, vm);
+
+      switch(type)
+      {
+      case ASSIGN:
+        DATA_CHECK(
+          code.get_statement() == ID_assign,
+          "assign instruction should contain an assign statement");
+        DATA_CHECK(
+          targets.empty(), "assign instruction should not have a target");
+        break;
+      default:
+        break;
+      }
     }
   };
 

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -398,6 +398,16 @@ public:
     /// only be evaluated in the context of a goto_programt (see
     /// goto_programt::equals).
     bool equals(const instructiont &other) const;
+
+    /// Check that the instruction is well-formed
+    ///
+    /// The validation mode indicates whether well-formedness check failures are
+    /// reported via DATA_INVARIANT violations or exceptions.
+    void validate(const namespacet &ns, const validation_modet vm) const
+    {
+      validate_code_full_pick(code, ns, vm);
+      validate_expr_full_pick(guard, ns, vm);
+    }
   };
 
   // Never try to change this to vector-we mutate the list while iterating
@@ -677,6 +687,18 @@ public:
   /// the same number of instructions, each pair of instructions compares equal,
   /// and relative jumps have the same distance.
   bool equals(const goto_programt &other) const;
+
+  /// Check that the goto program is well-formed
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate(const namespacet &ns, const validation_modet vm) const
+  {
+    for(const instructiont &ins : instructions)
+    {
+      ins.validate(ns, vm);
+    }
+  }
 };
 
 /// Get control-flow successors of a given instruction. The instruction is

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -404,24 +404,7 @@ public:
     ///
     /// The validation mode indicates whether well-formedness check failures are
     /// reported via DATA_INVARIANT violations or exceptions.
-    void validate(const namespacet &ns, const validation_modet vm) const
-    {
-      validate_code_full_pick(code, ns, vm);
-      validate_expr_full_pick(guard, ns, vm);
-
-      switch(type)
-      {
-      case ASSIGN:
-        DATA_CHECK(
-          code.get_statement() == ID_assign,
-          "assign instruction should contain an assign statement");
-        DATA_CHECK(
-          targets.empty(), "assign instruction should not have a target");
-        break;
-      default:
-        break;
-      }
-    }
+    void validate(const namespacet &ns, const validation_modet vm) const;
   };
 
   // Never try to change this to vector-we mutate the list while iterating

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -404,7 +404,7 @@ public:
     ///
     /// The validation mode indicates whether well-formedness check failures are
     /// reported via DATA_INVARIANT violations or exceptions.
-    void validate(const namespacet &ns, const validation_modet vm) const;
+    void validate(const symbol_tablet &table, const validation_modet vm) const;
   };
 
   // Never try to change this to vector-we mutate the list while iterating
@@ -689,11 +689,11 @@ public:
   ///
   /// The validation mode indicates whether well-formedness check failures are
   /// reported via DATA_INVARIANT violations or exceptions.
-  void validate(const namespacet &ns, const validation_modet vm) const
+  void validate(const symbol_tablet &table, const validation_modet vm) const
   {
     for(const instructiont &ins : instructions)
     {
-      ins.validate(ns, vm);
+      ins.validate(table, vm);
     }
   }
 };

--- a/src/goto-programs/initialize_goto_model.cpp
+++ b/src/goto-programs/initialize_goto_model.cpp
@@ -167,6 +167,12 @@ goto_modelt initialize_goto_model(
     goto_model.goto_functions,
     message_handler);
 
+  if(cmdline.isset("validate-goto-model"))
+  {
+    const namespacet ns(goto_model.symbol_table);
+    goto_model.validate(ns, validation_modet::EXCEPTION);
+  }
+
   // stupid hack
   config.set_object_bits_from_symbol_table(
     goto_model.symbol_table);

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -97,6 +97,7 @@ SRC = arith_tools.cpp \
       union_find_replace.cpp \
       unwrap_nested_exception.cpp \
       validate_expressions.cpp \
+      validate_types.cpp \
       version.cpp \
       xml.cpp \
       xml_expr.cpp \

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -96,6 +96,7 @@ SRC = arith_tools.cpp \
       union_find.cpp \
       union_find_replace.cpp \
       unwrap_nested_exception.cpp \
+      validate_code.cpp \
       validate_expressions.cpp \
       validate_types.cpp \
       version.cpp \

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -96,6 +96,7 @@ SRC = arith_tools.cpp \
       union_find.cpp \
       union_find_replace.cpp \
       unwrap_nested_exception.cpp \
+      validate_expressions.cpp \
       version.cpp \
       xml.cpp \
       xml_expr.cpp \

--- a/src/util/exception_utils.cpp
+++ b/src/util/exception_utils.cpp
@@ -55,26 +55,23 @@ std::string deserialization_exceptiont::what() const
 }
 
 incorrect_goto_program_exceptiont::incorrect_goto_program_exceptiont(
-  std::string message,
-  source_locationt source_location)
-  : message(std::move(message)), source_location(std::move(source_location))
-{
-}
-
-std::string incorrect_goto_program_exceptiont::what() const
-{
-  return message + " (at: " + source_location.as_string() + ")";
-  if(source_location.is_nil())
-    return message;
-  else
-    return message + " (at: " + source_location.as_string() + ")";
-}
-
-incorrect_goto_program_exceptiont::incorrect_goto_program_exceptiont(
   std::string message)
   : message(std::move(message))
 {
   source_location.make_nil();
+}
+
+std::string incorrect_goto_program_exceptiont::what() const
+{
+  std::string ret(message);
+
+  if(!source_location.is_nil())
+    ret += " (at: " + source_location.as_string() + ")";
+
+  if(!diagnostics.empty())
+    ret += "\n" + diagnostics;
+
+  return ret;
 }
 
 unsupported_operation_exceptiont::unsupported_operation_exceptiont(

--- a/src/util/exception_utils.h
+++ b/src/util/exception_utils.h
@@ -11,6 +11,7 @@ Author: Fotis Koutoulakis, fotis.koutoulakis@diffblue.com
 
 #include <string>
 
+#include "invariant.h"
 #include "source_location.h"
 
 /// Base class for exceptions thrown in the cprover project.
@@ -88,16 +89,53 @@ private:
 class incorrect_goto_program_exceptiont : public cprover_exception_baset
 {
 public:
+  explicit incorrect_goto_program_exceptiont(std::string message);
+
+  template <typename Diagnostic, typename... Diagnostics>
   incorrect_goto_program_exceptiont(
     std::string message,
-    source_locationt source_location);
-  explicit incorrect_goto_program_exceptiont(std::string message);
+    Diagnostic &&diagnostic,
+    Diagnostics &&... diagnostics);
+
+  template <typename... Diagnostics>
+  incorrect_goto_program_exceptiont(
+    std::string message,
+    source_locationt source_location,
+    Diagnostics &&... diagnostics);
+
   std::string what() const override;
 
 private:
   std::string message;
   source_locationt source_location;
+
+  std::string diagnostics;
 };
+
+template <typename Diagnostic, typename... Diagnostics>
+incorrect_goto_program_exceptiont::incorrect_goto_program_exceptiont(
+  std::string message,
+  Diagnostic &&diagnostic,
+  Diagnostics &&... diagnostics)
+  : message(std::move(message)),
+    diagnostics(
+      detail::assemble_diagnostics(
+        std::forward(diagnostic),
+        std::forward<Diagnostics>(diagnostics)...))
+{
+}
+
+template <typename... Diagnostics>
+incorrect_goto_program_exceptiont::incorrect_goto_program_exceptiont(
+  std::string message,
+  source_locationt source_location,
+  Diagnostics &&... diagnostics)
+  : message(std::move(message)),
+    source_location(std::move(source_location)),
+    diagnostics(
+      detail::assemble_diagnostics(std::forward<Diagnostics>(diagnostics)...))
+{
+}
 
 /// Thrown when we encounter an instruction, parameters to an instruction etc.
 /// in a goto program that has some theoretically valid semantics,

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -15,6 +15,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "expr.h"
 #include "expr_cast.h"
 #include "invariant.h"
+#include "validate.h"
+#include "validate_code.h"
 
 /// Data structure for representing an arbitrary statement in a program. Every
 /// specific type of statement (e.g. block of statements, assignment,
@@ -59,6 +61,49 @@ public:
   codet &last_statement();
   const codet &last_statement() const;
   class code_blockt &make_block();
+
+  /// Check that the code statement is well-formed (shallow checks only, i.e.,
+  /// enclosed statements, subexpressions, etc. are not checked)
+  ///
+  /// Subclasses may override this method to provide specific well-formedness
+  /// checks for the corresponding types.
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void check(const validation_modet vm = validation_modet::INVARIANT) const
+  {
+  }
+
+  /// Check that the code statement is well-formed, assuming that all its
+  /// enclosed statements, subexpressions, etc. have all ready been checked for
+  /// well-formedness.
+  ///
+  /// Subclasses may override this method to provide specific well-formedness
+  /// checks for the corresponding types.
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    check_code_pick(*this, vm);
+  }
+
+  /// Check that the code statement is well-formed (full check, including checks
+  /// of all subexpressions)
+  ///
+  /// Subclasses may override this method to provide specific well-formedness
+  /// checks for the corresponding types.
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate_full(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    check_code_pick(*this, vm);
+  }
 };
 
 namespace detail // NOLINT

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <list>
 
+#include "base_type.h"
 #include "expr.h"
 #include "expr_cast.h"
 #include "invariant.h"
@@ -286,6 +287,34 @@ public:
   {
     return op1();
   }
+
+  void check(const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    DATA_CHECK(operands().size() == 2, "assignment must have two operands");
+  }
+
+  void validate(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    check(vm);
+
+    DATA_CHECK(
+      base_type_eq(lhs().type(), rhs().type(), ns),
+      "lhs and rhs of assignment must have same type");
+  }
+
+  void validate_full(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    for(const exprt &op : operands())
+    {
+      validate_expr_full_pick(op, ns, vm);
+    }
+
+    validate(ns, vm);
+  }
 };
 
 template<> inline bool can_cast_expr<code_assignt>(const exprt &base)
@@ -301,17 +330,17 @@ inline void validate_expr(const code_assignt & x)
 inline const code_assignt &to_code_assign(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_assign);
-  DATA_INVARIANT(
-    code.operands().size() == 2, "assignment must have two operands");
-  return static_cast<const code_assignt &>(code);
+  const code_assignt &ret = static_cast<const code_assignt &>(code);
+  ret.check();
+  return ret;
 }
 
 inline code_assignt &to_code_assign(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_assign);
-  DATA_INVARIANT(
-    code.operands().size() == 2, "assignment must have two operands");
-  return static_cast<code_assignt &>(code);
+  code_assignt &ret = static_cast<code_assignt &>(code);
+  ret.check();
+  return ret;
 }
 
 /// A `codet` representing the declaration of a local variable.

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "expr.h"
 #include "expr_cast.h"
 #include "invariant.h"
+#include "std_types.h"
 #include "validate.h"
 #include "validate_code.h"
 
@@ -1056,7 +1057,7 @@ public:
   void check(const validation_modet vm = validation_modet::INVARIANT) const
   {
     DATA_CHECK(
-      operands().size() == 3, "function calls must have three operand");
+      operands().size() == 3, "function calls must have three operands");
   }
 
   void validate(
@@ -1064,9 +1065,14 @@ public:
     const validation_modet vm = validation_modet::INVARIANT) const
   {
     check(vm);
-    if(lhs().id() != ID_nil)
+    if(lhs().id() == ID_nil)
       DATA_CHECK(
-        base_type_eq(lhs().type(), function().type(), ns),
+        to_code_type(function().type()).return_type().id() == ID_nil,
+        "void function should not return value");
+    else
+      DATA_CHECK(
+        base_type_eq(
+          lhs().type(), to_code_type(function().type()).return_type(), ns),
         "function returns expression of wrong type");
   }
 
@@ -1077,11 +1083,6 @@ public:
     for(const exprt &op : operands())
     {
       validate_expr_full_pick(op, ns, vm);
-    }
-
-    for(const exprt &arg : op2().operands())
-    {
-      validate_expr_full_pick(arg, ns, vm);
     }
 
     validate(ns, vm);

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -508,6 +508,11 @@ inline code_assumet &to_code_assume(codet &code)
   return static_cast<code_assumet &>(code);
 }
 
+inline void validate_expr(const code_assumet &x)
+{
+  validate_operands(x, 1, "assume must have one operand");
+}
+
 /// A non-fatal assertion, which checks a condition then permits execution to
 /// continue.
 class code_assertt:public codet
@@ -553,6 +558,11 @@ inline code_assertt &to_code_assert(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_assert);
   return static_cast<code_assertt &>(code);
+}
+
+inline void validate_expr(const code_assertt &x)
+{
+  validate_operands(x, 1, "assert must have one operand");
 }
 
 /// Create a fatal assertion, which checks a condition and then halts if it does

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -373,6 +373,30 @@ public:
   }
 
   const irep_idt &get_identifier() const;
+
+  void check(const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    DATA_CHECK(operands().size() == 1, "declaration must have one operand");
+    DATA_CHECK(
+      symbol().id() == ID_symbol,
+      "declaring a non-symbol: " + id2string(get_identifier()));
+  }
+
+  void validate(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    check(vm);
+  }
+
+  void validate_full(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    validate_expr_full_pick(symbol(), ns, vm);
+
+    validate(ns, vm);
+  }
 };
 
 template<> inline bool can_cast_expr<code_declt>(const exprt &base)
@@ -435,6 +459,31 @@ public:
   }
 
   const irep_idt &get_identifier() const;
+
+  void check(const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    DATA_CHECK(
+      operands().size() == 1, "removal (code_deadt) must have one operand");
+    DATA_CHECK(
+      symbol().id() == ID_symbol,
+      "removing a non-symbol: " + id2string(get_identifier()) + "from scope");
+  }
+
+  void validate(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    check(vm);
+  }
+
+  void validate_full(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    validate_expr_full_pick(symbol(), ns, vm);
+
+    validate(ns, vm);
+  }
 };
 
 template<> inline bool can_cast_expr<code_deadt>(const exprt &base)
@@ -1067,7 +1116,7 @@ public:
     check(vm);
     if(lhs().id() == ID_nil)
       DATA_CHECK(
-        to_code_type(function().type()).return_type().id() == ID_nil,
+        to_code_type(function().type()).return_type().id() == ID_empty,
         "void function should not return value");
     else
       DATA_CHECK(

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -1052,6 +1052,40 @@ public:
   {
     return op2().operands();
   }
+
+  void check(const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    DATA_CHECK(
+      operands().size() == 3, "function calls must have three operand");
+  }
+
+  void validate(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    check(vm);
+    if(lhs().id() != ID_nil)
+      DATA_CHECK(
+        base_type_eq(lhs().type(), function().type(), ns),
+        "function returns expression of wrong type");
+  }
+
+  void validate_full(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    for(const exprt &op : operands())
+    {
+      validate_expr_full_pick(op, ns, vm);
+    }
+
+    for(const exprt &arg : op2().operands())
+    {
+      validate_expr_full_pick(arg, ns, vm);
+    }
+
+    validate(ns, vm);
+  }
 };
 
 template<> inline bool can_cast_expr<code_function_callt>(const exprt &base)
@@ -1072,6 +1106,11 @@ inline code_function_callt &to_code_function_call(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_function_call);
   return static_cast<code_function_callt &>(code);
+}
+
+inline void validate_expr(const code_function_callt &x)
+{
+  validate_operands(x, 3, "function calls must have three operands");
 }
 
 /// \ref codet representation of a "return from a function" statement.
@@ -1105,6 +1144,30 @@ public:
       return false; // backwards compatibility
     return return_value().is_not_nil();
   }
+
+  void check(const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    DATA_CHECK(operands().size() == 1, "return must have one operand");
+  }
+
+  void validate(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    check(vm);
+  }
+
+  void validate_full(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    for(const exprt &op : operands())
+    {
+      validate_expr_full_pick(op, ns, vm);
+    }
+
+    validate(ns, vm);
+  }
 };
 
 template<> inline bool can_cast_expr<code_returnt>(const exprt &base)
@@ -1125,6 +1188,11 @@ inline code_returnt &to_code_return(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_return);
   return static_cast<code_returnt &>(code);
+}
+
+inline void validate_expr(const code_returnt &x)
+{
+  validate_operands(x, 1, "return must have one operand");
 }
 
 /// \ref codet representation of a label for branch targets.

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file util/std_expr.h
 /// API to expression classes
 
+#include "base_type.h"
 #include "expr_cast.h"
 #include "invariant.h"
 #include "mathematical_types.h"
@@ -1414,6 +1415,26 @@ public:
     binary_relation_exprt(_lhs, ID_equal, _rhs)
   {
   }
+
+  void check(const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    DATA_CHECK(operands().size() == 2, "equality must have two operands");
+  }
+
+  void validate(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    check(vm);
+
+    // check types
+    DATA_CHECK(
+      base_type_eq(lhs().type(), rhs().type(), ns),
+      "lhs and rhs should have same type");
+    DATA_CHECK(
+      type().id() == ID_bool,
+      "result of equal expression should be of type bool");
+  }
 };
 
 /// \brief Cast an exprt to an \ref equal_exprt
@@ -1425,16 +1446,18 @@ public:
 inline const equal_exprt &to_equal_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_equal);
-  DATA_INVARIANT(expr.operands().size()==2, "Equality must have two operands");
-  return static_cast<const equal_exprt &>(expr);
+  const equal_exprt &ret = static_cast<const equal_exprt &>(expr);
+  ret.check();
+  return ret;
 }
 
 /// \copydoc to_equal_expr(const exprt &)
 inline equal_exprt &to_equal_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_equal);
-  DATA_INVARIANT(expr.operands().size()==2, "Equality must have two operands");
-  return static_cast<equal_exprt &>(expr);
+  equal_exprt &ret = static_cast<equal_exprt &>(expr);
+  ret.check();
+  return ret;
 }
 
 template<> inline bool can_cast_expr<equal_exprt>(const exprt &base)

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -1260,6 +1260,12 @@ public:
   constant_exprt smallest_expr() const;
   constant_exprt zero_expr() const;
   constant_exprt largest_expr() const;
+
+  void check(const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    DATA_CHECK(
+      !get(ID_width).empty(), "unsigned bitvector type must have width");
+  }
 };
 
 /// Check whether a reference to a typet is a \ref unsignedbv_typet.
@@ -1269,12 +1275,6 @@ template <>
 inline bool can_cast_type<unsignedbv_typet>(const typet &type)
 {
   return type.id() == ID_unsignedbv;
-}
-
-inline void validate_type(const unsignedbv_typet &type)
-{
-  DATA_INVARIANT(
-    !type.get(ID_width).empty(), "unsigned bitvector type must have width");
 }
 
 /// \brief Cast a typet to an \ref unsignedbv_typet
@@ -1289,7 +1289,7 @@ inline const unsignedbv_typet &to_unsignedbv_type(const typet &type)
 {
   PRECONDITION(can_cast_type<unsignedbv_typet>(type));
   const unsignedbv_typet &ret = static_cast<const unsignedbv_typet &>(type);
-  validate_type(ret);
+  ret.check();
   return ret;
 }
 
@@ -1298,7 +1298,7 @@ inline unsignedbv_typet &to_unsignedbv_type(typet &type)
 {
   PRECONDITION(can_cast_type<unsignedbv_typet>(type));
   unsignedbv_typet &ret = static_cast<unsignedbv_typet &>(type);
-  validate_type(ret);
+  ret.check();
   return ret;
 }
 

--- a/src/util/symbol_table.h
+++ b/src/util/symbol_table.h
@@ -109,6 +109,11 @@ public:
   {
     return iteratort(internal_symbols.end());
   }
+
+  /// Check that the symbol table is well-formed
+  void validate() const
+  {
+  }
 };
 
 #endif // CPROVER_UTIL_SYMBOL_TABLE_H

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -13,7 +13,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_TYPE_H
 #define CPROVER_UTIL_TYPE_H
 
+class namespacet;
+
 #include "source_location.h"
+#include "validate.h"
+#include "validate_types.h"
 
 /// The type of an expression, extends irept. Types may have subtypes. This is
 /// modeled with two subs named “subtype” (a single type) and “subtypes”
@@ -73,6 +77,55 @@ public:
   const typet &find_type(const irep_namet &name) const
   {
     return static_cast<const typet &>(find(name));
+  }
+
+  /// Check that the type is well-formed (shallow checks only, i.e., subtypes
+  /// are not checked)
+  ///
+  /// Subclasses may override this method to provide specific well-formedness
+  /// checks for the corresponding types.
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void check(const validation_modet vm = validation_modet::INVARIANT) const
+  {
+  }
+
+  /// Check that the type is well-formed, assuming that its subtypes have
+  /// already been checked for well-formedness.
+  ///
+  /// Subclasses may override this method to provide specific well-formedness
+  /// checks for the corresponding types.
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    check_type_pick(*this, vm);
+  }
+
+  /// Check that the type is well-formed (full check, including checks of
+  /// subtypes)
+  ///
+  /// Subclasses may override this method, though in most cases the provided
+  /// implementation should be sufficient.
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate_full(
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT) const
+  {
+    // check subtypes
+    for(const irept &sub : get_sub())
+    {
+      const typet &subtype = static_cast<const typet &>(sub);
+      validate_type_full_pick(subtype, ns, vm);
+    }
+
+    validate_type_pick(*this, ns, vm);
   }
 };
 

--- a/src/util/validate.h
+++ b/src/util/validate.h
@@ -1,0 +1,69 @@
+/*******************************************************************\
+
+Module: Goto program validation
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_VALIDATE_H
+#define CPROVER_UTIL_VALIDATE_H
+
+#include <type_traits>
+
+#include "exception_utils.h"
+#include "invariant.h"
+#include "irep.h"
+
+enum class validation_modet
+{
+  INVARIANT,
+  EXCEPTION
+};
+
+/// This macro takes a condition which denotes a well-formedness criterion on
+/// goto programs, expressions, instructions, etc. When invoking the macro, a
+/// variable named `vm` of type `const validation_modet` should be in scope. It
+/// indicates whether DATA_INVARIANT() is used to check the condition, or if an
+/// exception is thrown when the condition does not hold.
+#define DATA_CHECK(condition, message)                                         \
+  do                                                                           \
+  {                                                                            \
+    static_assert(                                                             \
+      std::is_same<decltype(vm), const validation_modet>::value,               \
+      "when invoking the macro DATA_CHECK(), a variable named `vm` of type "   \
+      "`const validation_modet` should be in scope which indicates the "       \
+      "validation mode (see `validate.h`");                                    \
+    switch(vm)                                                                 \
+    {                                                                          \
+    case validation_modet::INVARIANT:                                          \
+      DATA_INVARIANT(condition, message);                                      \
+      break;                                                                   \
+    case validation_modet::EXCEPTION:                                          \
+      if(!(condition))                                                         \
+        throw incorrect_goto_program_exceptiont(message);                      \
+      break;                                                                   \
+    }                                                                          \
+  } while(0)
+
+#define DATA_CHECK_WITH_DIAGNOSTICS(condition, message, ...)                   \
+  do                                                                           \
+  {                                                                            \
+    static_assert(                                                             \
+      std::is_same<decltype(vm), const validation_modet>::value,               \
+      "when invoking the macro DATA_CHECK_WITH_DIAGNOSTICS(), a variable "     \
+      "named `vm` of type `const validation_modet` should be in scope which "  \
+      "indicates the validation mode (see `validate.h`");                      \
+    switch(vm)                                                                 \
+    {                                                                          \
+    case validation_modet::INVARIANT:                                          \
+      DATA_INVARIANT_WITH_DIAGNOSTICS(condition, message, __VA_ARGS__);        \
+      break;                                                                   \
+    case validation_modet::EXCEPTION:                                          \
+      if(!(condition))                                                         \
+        throw incorrect_goto_program_exceptiont(message, __VA_ARGS__);         \
+      break;                                                                   \
+    }                                                                          \
+  } while(0)
+
+#endif /* CPROVER_UTIL_VALIDATE_H */

--- a/src/util/validate.h
+++ b/src/util/validate.h
@@ -66,4 +66,42 @@ enum class validation_modet
     }                                                                          \
   } while(0)
 
+template <typename T>
+struct call_checkt
+{
+  static_assert(std::is_base_of<irept, T>::value, "");
+
+  void operator()(const irept &irep, const validation_modet vm)
+  {
+    const T &s = static_cast<const T &>(irep);
+    s.check(vm);
+  }
+};
+
+template <typename T>
+struct call_validatet
+{
+  static_assert(std::is_base_of<irept, T>::value, "");
+
+  void
+  operator()(const irept &irep, const namespacet &ns, const validation_modet vm)
+  {
+    const T &s = static_cast<const T &>(irep);
+    s.validate(ns, vm);
+  }
+};
+
+template <typename T>
+struct call_validate_fullt
+{
+  static_assert(std::is_base_of<irept, T>::value, "");
+
+  void
+  operator()(const irept &irep, const namespacet &ns, const validation_modet vm)
+  {
+    const T &s = static_cast<const T &>(irep);
+    s.validate_full(ns, vm);
+  }
+};
+
 #endif /* CPROVER_UTIL_VALIDATE_H */

--- a/src/util/validate_code.cpp
+++ b/src/util/validate_code.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************\
+
+Module: Validate code
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#include "validate_code.h"
+
+#ifdef REPORT_UNIMPLEMENTED_CODE_CHECKS
+#include <iostream>
+#endif
+
+#include "namespace.h"
+#include "std_code.h"
+#include "validate.h"
+
+#define CALL_ON_CODE(code_type)                                                \
+  C<code_type>()(code, std::forward<Args>(args)...)
+
+template <template <typename> class C, typename... Args>
+void call_on_code(const codet &code, Args &&... args)
+{
+  if(code.get_statement() == ID_assign)
+  {
+    CALL_ON_CODE(code_assignt);
+  }
+  else if(code.get_statement() == ID_decl)
+  {
+    CALL_ON_CODE(code_declt);
+  }
+  else
+  {
+#ifdef REPORT_UNIMPLEMENTED_CODE_CHECKS
+    std::cerr << "Unimplemented well-formedness check for code statement with "
+                 "id: "
+              << code.get_statement().id_string() << std::endl;
+#endif
+
+    CALL_ON_CODE(codet);
+  }
+}
+
+/// Check that the given code statement is well-formed (shallow checks only,
+/// i.e., enclosed statements, subexpressions, etc. are not checked)
+///
+/// The function casts the given codet statement to its concrete subtype (as
+/// determined by the id() field) and then calls its check() method.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void check_code_pick(const codet &code, const validation_modet vm)
+{
+  call_on_code<call_checkt>(code, vm);
+}
+
+/// Check that the given code statement is well-formed, assuming that all its
+/// enclosed statements, subexpressions, etc. have already been checked for
+/// well-formedness.
+///
+/// The function casts the given codet statement to its concrete subtype (as
+/// determined by the id() field) and then calls its validate() method.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void validate_code_pick(
+  const codet &code,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  call_on_code<call_validatet>(code, ns, vm);
+}
+
+/// Check that the given code statement is well-formed (full check, including
+/// checks of all subexpressions)
+///
+/// The function casts the given codet statement to its concrete subtype (as
+/// determined by the id() field) and then calls its validate_full() method.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void validate_code_full_pick(
+  const codet &code,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  call_on_code<call_validate_fullt>(code, ns, vm);
+}

--- a/src/util/validate_code.cpp
+++ b/src/util/validate_code.cpp
@@ -30,6 +30,14 @@ void call_on_code(const codet &code, Args &&... args)
   {
     CALL_ON_CODE(code_declt);
   }
+  else if(code.get_statement() == ID_function_call)
+  {
+    CALL_ON_CODE(code_function_callt);
+  }
+  else if(code.get_statement() == ID_return)
+  {
+    CALL_ON_CODE(code_returnt);
+  }
   else
   {
 #ifdef REPORT_UNIMPLEMENTED_CODE_CHECKS

--- a/src/util/validate_code.cpp
+++ b/src/util/validate_code.cpp
@@ -38,6 +38,14 @@ void call_on_code(const codet &code, Args &&... args)
   {
     CALL_ON_CODE(code_returnt);
   }
+  else if(code.get_statement() == ID_decl)
+  {
+    CALL_ON_CODE(code_declt);
+  }
+  else if(code.get_statement() == ID_dead)
+  {
+    CALL_ON_CODE(code_deadt);
+  }
   else
   {
 #ifdef REPORT_UNIMPLEMENTED_CODE_CHECKS

--- a/src/util/validate_code.h
+++ b/src/util/validate_code.h
@@ -1,0 +1,28 @@
+/*******************************************************************\
+
+Module: Validate code
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_VALIDATE_CODE_H
+#define CPROVER_UTIL_VALIDATE_CODE_H
+
+class codet;
+class namespacet;
+enum class validation_modet;
+
+void check_code_pick(const codet &code, const validation_modet vm);
+
+void validate_code_pick(
+  const codet &code,
+  const namespacet &ns,
+  const validation_modet vm);
+
+void validate_code_full_pick(
+  const codet &code,
+  const namespacet &ns,
+  const validation_modet vm);
+
+#endif /* CPROVER_UTIL_VALIDATE_CODE_H */

--- a/src/util/validate_expressions.cpp
+++ b/src/util/validate_expressions.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************\
+
+Module: Validate expressions
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#include "validate_expressions.h"
+
+#ifdef REPORT_UNIMPLEMENTED_EXPRESSION_CHECKS
+#include <iostream>
+#endif
+
+#include "expr.h"
+#include "namespace.h"
+#include "std_expr.h"
+#include "validate.h"
+
+#define CALL_ON_EXPR(expr_type)                                                \
+  C<expr_type>()(expr, std::forward<Args>(args)...)
+
+template <template <typename> class C, typename... Args>
+void call_on_expr(const exprt &expr, Args &&... args)
+{
+  if(expr.id() == ID_equal)
+  {
+    CALL_ON_EXPR(equal_exprt);
+  }
+  else if(expr.id() == ID_plus)
+  {
+    CALL_ON_EXPR(plus_exprt);
+  }
+  else
+  {
+#ifdef REPORT_UNIMPLEMENTED_EXPRESSION_CHECKS
+    std::cerr << "Unimplemented well-formedness check for expression with id: "
+              << expr.id_string() std::endl;
+#endif
+
+    CALL_ON_EXPR(exprt);
+  }
+}
+
+/// Check that the given expression is well-formed (shallow checks only, i.e.,
+/// subexpressions and its type are not checked)
+///
+/// The function casts the given expression to its concrete subtype (as
+/// determined by the id() field) and then calls its check() method.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void check_expr_pick(const exprt &expr, const validation_modet vm)
+{
+  call_on_expr<call_checkt>(expr, vm);
+}
+
+/// Check that the given expression is well-formed, assuming that its
+/// subexpression and type have already been checked for well-formedness.
+///
+/// The function casts the given expression to its concrete subtype (as
+/// determined by the id() field) and then calls its validate() method.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void validate_expr_pick(
+  const exprt &expr,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  call_on_expr<call_validatet>(expr, ns, vm);
+}
+
+/// Check that the given expression is well-formed (full check, including checks
+/// of all subexpressions and the type)
+///
+/// The function casts the given expression to its concrete subtype (as
+/// determined by the id() field) and then calls its validate_full() method.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void validate_expr_full_pick(
+  const exprt &expr,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  call_on_expr<call_validate_fullt>(expr, ns, vm);
+}

--- a/src/util/validate_expressions.h
+++ b/src/util/validate_expressions.h
@@ -1,0 +1,28 @@
+/*******************************************************************\
+
+Module: Validate expressions
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_VALIDATE_EXPRESSIONS_H
+#define CPROVER_UTIL_VALIDATE_EXPRESSIONS_H
+
+class exprt;
+class namespacet;
+enum class validation_modet;
+
+void check_expr_pick(const exprt &expr, const validation_modet vm);
+
+void validate_expr_pick(
+  const exprt &expr,
+  const namespacet &ns,
+  const validation_modet vm);
+
+void validate_expr_full_pick(
+  const exprt &expr,
+  const namespacet &ns,
+  const validation_modet vm);
+
+#endif /* CPROVER_UTIL_VALIDATE_EXPRESSIONS_H */

--- a/src/util/validate_types.cpp
+++ b/src/util/validate_types.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************\
+
+Module: Validate types
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#include "validate_types.h"
+
+#ifdef REPORT_UNIMPLEMENTED_TYPE_CHECKS
+#include <iostream>
+#endif
+
+#include "namespace.h"
+#include "std_types.h"
+#include "type.h"
+#include "validate.h"
+
+#define CALL_ON_TYPE(type_type)                                                \
+  C<type_type>()(type, std::forward<Args>(args)...)
+
+template <template <typename> class C, typename... Args>
+void call_on_type(const typet &type, Args &&... args)
+{
+  if(type.id() == ID_signedbv)
+  {
+    CALL_ON_TYPE(signedbv_typet);
+  }
+  else if(type.id() == ID_unsignedbv)
+  {
+    CALL_ON_TYPE(unsignedbv_typet);
+  }
+  else
+  {
+#ifdef REPORT_UNIMPLEMENTED_TYPE_CHECKS
+    std::cerr << "Unimplemented well-formedness check for type with id: "
+              << type.id_string() << std::endl;
+#endif
+
+    CALL_ON_TYPE(typet);
+  }
+}
+
+/// Check that the given type is well-formed (shallow checks only, i.e.,
+/// subtypes are not checked)
+///
+/// The function casts the given type to its concrete subtype (as determined by
+/// the id() field) and then calls its check() method.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void check_type_pick(const typet &type, const validation_modet vm)
+{
+  call_on_type<call_checkt>(type, vm);
+}
+
+/// Check that the given type is well-formed, assuming that its subtypes have
+/// already been checked for well-formedness.
+///
+/// The function casts the given type to its concrete subtype (as determined by
+/// the id() field) and then calls its validate() method.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void validate_type_pick(
+  const typet &type,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  call_on_type<call_validatet>(type, ns, vm);
+}
+
+/// Check that the given type is well-formed (full check, including checks of
+/// subtypes)
+///
+/// The function casts the given type to its concrete subtype (as determined by
+/// the id() field) and then calls its validate_full() method.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void validate_type_full_pick(
+  const typet &type,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  call_on_type<call_validate_fullt>(type, ns, vm);
+}

--- a/src/util/validate_types.h
+++ b/src/util/validate_types.h
@@ -1,0 +1,28 @@
+/*******************************************************************\
+
+Module: Validate types
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_VALIDATE_TYPES_H
+#define CPROVER_UTIL_VALIDATE_TYPES_H
+
+class typet;
+class namespacet;
+enum class validation_modet;
+
+void check_type_pick(const typet &type, const validation_modet vm);
+
+void validate_type_pick(
+  const typet &type,
+  const namespacet &ns,
+  const validation_modet vm);
+
+void validate_type_full_pick(
+  const typet &type,
+  const namespacet &ns,
+  const validation_modet vm);
+
+#endif /* CPROVER_UTIL_VALIDATE_TYPES_H */

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -16,6 +16,7 @@ SRC += analyses/ai/ai.cpp \
        analyses/does_remove_const/is_type_at_least_as_const_as.cpp \
        goto-programs/goto_trace_output.cpp \
        goto-programs/goto_program_assign.cpp \
+       goto-programs/goto_program_goto_target.cpp \
        interpreter/interpreter.cpp \
        json/json_parser.cpp \
        path_strategies.cpp \

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -17,6 +17,7 @@ SRC += analyses/ai/ai.cpp \
        goto-programs/goto_trace_output.cpp \
        goto-programs/goto_program_assign.cpp \
        goto-programs/goto_program_goto_target.cpp \
+       goto-programs/goto_program_function_call.cpp \
        interpreter/interpreter.cpp \
        json/json_parser.cpp \
        path_strategies.cpp \

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -15,6 +15,7 @@ SRC += analyses/ai/ai.cpp \
        analyses/does_remove_const/does_type_preserve_const_correctness.cpp \
        analyses/does_remove_const/is_type_at_least_as_const_as.cpp \
        goto-programs/goto_trace_output.cpp \
+       goto-programs/goto_program_assign.cpp \
        interpreter/interpreter.cpp \
        json/json_parser.cpp \
        path_strategies.cpp \

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -18,6 +18,7 @@ SRC += analyses/ai/ai.cpp \
        goto-programs/goto_program_assign.cpp \
        goto-programs/goto_program_goto_target.cpp \
        goto-programs/goto_program_function_call.cpp \
+       goto-programs/goto_program_declaration.cpp \
        interpreter/interpreter.cpp \
        json/json_parser.cpp \
        path_strategies.cpp \

--- a/unit/goto-programs/goto_program_assign.cpp
+++ b/unit/goto-programs/goto_program_assign.cpp
@@ -1,0 +1,66 @@
+/*******************************************************************\
+
+  Module: Unit tests for goto_program::validate
+
+  Author: Diffblue Ltd.
+
+ \*******************************************************************/
+
+#include <goto-programs/goto_function.h>
+#include <testing-utils/catch.hpp>
+#include <util/arith_tools.h>
+
+SCENARIO(
+  "Validation of well-formed assert/assume codes",
+  "[core][goto-programs][validate]")
+{
+  GIVEN("A program with one assertion")
+  {
+    symbol_tablet symbol_table;
+    const typet type1 = signedbv_typet(32);
+    symbolt symbol;
+    irep_idt symbol_name = "a";
+    symbol.name = symbol_name;
+    symbol_exprt varx(symbol_name, type1);
+    exprt val10 = from_integer(10, type1);
+    plus_exprt x_plus_10(varx, val10);
+    binary_relation_exprt x_le_10(varx, ID_le, val10);
+
+    goto_functiont goto_function;
+    auto &instructions = goto_function.body.instructions;
+    instructions.emplace_back(goto_program_instruction_typet::ASSERT);
+
+    symbol.type = type1;
+    symbol_table.insert(symbol);
+    namespacet ns(symbol_table);
+
+    WHEN("Condition evaluates to a Boolean")
+    {
+      instructions.back().make_assertion(x_le_10);
+      THEN("The consistency check succeeds")
+      {
+        goto_function.body.validate(ns, validation_modet::INVARIANT);
+        REQUIRE(true);
+      }
+    }
+
+    WHEN("Condition does not evaluate to a Boolean")
+    {
+      instructions.back().make_assertion(x_plus_10);
+
+      THEN("The consistency check fails")
+      {
+        bool caught = false;
+        try
+        {
+          goto_function.body.validate(ns, validation_modet::EXCEPTION);
+        }
+        catch(incorrect_goto_program_exceptiont &e)
+        {
+          caught = true;
+        }
+        REQUIRE(caught);
+      }
+    }
+  }
+}

--- a/unit/goto-programs/goto_program_assign.cpp
+++ b/unit/goto-programs/goto_program_assign.cpp
@@ -39,7 +39,7 @@ SCENARIO(
       instructions.back().make_assertion(x_le_10);
       THEN("The consistency check succeeds")
       {
-        goto_function.body.validate(ns, validation_modet::INVARIANT);
+        goto_function.body.validate(symbol_table, validation_modet::INVARIANT);
         REQUIRE(true);
       }
     }
@@ -53,7 +53,8 @@ SCENARIO(
         bool caught = false;
         try
         {
-          goto_function.body.validate(ns, validation_modet::EXCEPTION);
+          goto_function.body.validate(
+            symbol_table, validation_modet::EXCEPTION);
         }
         catch(incorrect_goto_program_exceptiont &e)
         {

--- a/unit/goto-programs/goto_program_declaration.cpp
+++ b/unit/goto-programs/goto_program_declaration.cpp
@@ -11,47 +11,30 @@
 #include <util/arith_tools.h>
 
 SCENARIO(
-  "Validation of well-formed function call codes",
+  "Validation of well-formed declaration codes",
   "[core][goto-programs][validate]")
 {
-  GIVEN("A program with one function call")
+  GIVEN("A program with one declaration")
   {
     symbol_tablet symbol_table;
     const signedbv_typet type1(32);
-    const signedbv_typet type2(64);
-    const code_typet code_type({}, type1);
 
     symbolt var_symbol;
     irep_idt var_symbol_name = "a";
+    var_symbol.type = type1;
     var_symbol.name = var_symbol_name;
     symbol_exprt var_a(var_symbol_name, type1);
 
-    symbolt var_symbol2;
-    irep_idt var_symbol_name2 = "b";
-    var_symbol2.name = var_symbol_name2;
-    symbol_exprt var_b(var_symbol_name2, type2);
-
-    symbolt fun_symbol;
-    irep_idt fun_symbol_name = "foo";
-    fun_symbol.name = fun_symbol_name;
-    symbol_exprt fun_foo(fun_symbol_name, code_type);
-
     goto_functiont goto_function;
     auto &instructions = goto_function.body.instructions;
-    instructions.emplace_back(goto_program_instruction_typet::FUNCTION_CALL);
+    instructions.emplace_back(goto_program_instruction_typet::DECL);
+    code_declt declaration(var_a);
+    instructions.back().make_decl(declaration);
 
-    var_symbol.type = type1;
-    var_symbol2.type = type2;
-    fun_symbol.type = type1;
-    symbol_table.insert(var_symbol);
-    symbol_table.insert(var_symbol2);
-    symbol_table.insert(fun_symbol);
-    namespacet ns(symbol_table);
-
-    WHEN("Return type matches")
+    WHEN("Declaring known symbol")
     {
-      code_function_callt function_call(var_a, fun_foo, {});
-      instructions.back().make_function_call(function_call);
+      symbol_table.insert(var_symbol);
+      namespacet ns(symbol_table);
 
       THEN("The consistency check succeeds")
       {
@@ -60,11 +43,8 @@ SCENARIO(
       }
     }
 
-    WHEN("Return type differs from function type")
+    WHEN("Declaring unknown symbol")
     {
-      code_function_callt function_call(var_b, fun_foo, {});
-      instructions.back().make_function_call(function_call);
-
       THEN("The consistency check fails")
       {
         bool caught = false;

--- a/unit/goto-programs/goto_program_function_call.cpp
+++ b/unit/goto-programs/goto_program_function_call.cpp
@@ -17,8 +17,9 @@ SCENARIO(
   GIVEN("A program with one function call")
   {
     symbol_tablet symbol_table;
-    const typet type1 = signedbv_typet(32);
-    const typet type2 = signedbv_typet(64);
+    const signedbv_typet type1(32);
+    const signedbv_typet type2(64);
+    const code_typet code_type({}, type1);
 
     symbolt var_symbol;
     irep_idt var_symbol_name = "a";
@@ -33,7 +34,7 @@ SCENARIO(
     symbolt fun_symbol;
     irep_idt fun_symbol_name = "foo";
     fun_symbol.name = fun_symbol_name;
-    symbol_exprt fun_foo(fun_symbol_name, type1);
+    symbol_exprt fun_foo(fun_symbol_name, code_type);
 
     goto_functiont goto_function;
     auto &instructions = goto_function.body.instructions;

--- a/unit/goto-programs/goto_program_function_call.cpp
+++ b/unit/goto-programs/goto_program_function_call.cpp
@@ -1,0 +1,82 @@
+/*******************************************************************\
+
+  Module: Unit tests for goto_program::validate
+
+  Author: Diffblue Ltd.
+
+ \*******************************************************************/
+
+#include <goto-programs/goto_function.h>
+#include <testing-utils/catch.hpp>
+#include <util/arith_tools.h>
+
+SCENARIO(
+  "Validation of well-formed function call codes",
+  "[core][goto-programs][validate]")
+{
+  GIVEN("A program with one function call")
+  {
+    symbol_tablet symbol_table;
+    const typet type1 = signedbv_typet(32);
+    const typet type2 = signedbv_typet(64);
+
+    symbolt var_symbol;
+    irep_idt var_symbol_name = "a";
+    var_symbol.name = var_symbol_name;
+    symbol_exprt var_a(var_symbol_name, type1);
+
+    symbolt var_symbol2;
+    irep_idt var_symbol_name2 = "b";
+    var_symbol2.name = var_symbol_name2;
+    symbol_exprt var_b(var_symbol_name2, type2);
+
+    symbolt fun_symbol;
+    irep_idt fun_symbol_name = "foo";
+    fun_symbol.name = fun_symbol_name;
+    symbol_exprt fun_foo(fun_symbol_name, type1);
+
+    goto_functiont goto_function;
+    auto &instructions = goto_function.body.instructions;
+    instructions.emplace_back(goto_program_instruction_typet::FUNCTION_CALL);
+
+    var_symbol.type = type1;
+    var_symbol2.type = type2;
+    fun_symbol.type = type1;
+    symbol_table.insert(var_symbol);
+    symbol_table.insert(var_symbol2);
+    symbol_table.insert(fun_symbol);
+    namespacet ns(symbol_table);
+
+    WHEN("Return type matches")
+    {
+      code_function_callt function_call(var_a, fun_foo, {});
+      instructions.back().make_function_call(function_call);
+
+      THEN("The consistency check succeeds")
+      {
+        goto_function.body.validate(ns, validation_modet::INVARIANT);
+        REQUIRE(true);
+      }
+    }
+
+    WHEN("Return type differs from function type")
+    {
+      code_function_callt function_call(var_b, fun_foo, {});
+      instructions.back().make_function_call(function_call);
+
+      THEN("The consistency check fails")
+      {
+        bool caught = false;
+        try
+        {
+          goto_function.body.validate(ns, validation_modet::EXCEPTION);
+        }
+        catch(incorrect_goto_program_exceptiont &e)
+        {
+          caught = true;
+        }
+        REQUIRE(caught);
+      }
+    }
+  }
+}

--- a/unit/goto-programs/goto_program_goto_target.cpp
+++ b/unit/goto-programs/goto_program_goto_target.cpp
@@ -1,0 +1,67 @@
+/*******************************************************************\
+
+  Module: Unit tests for goto_program::validate
+
+  Author: Diffblue Ltd.
+
+ \*******************************************************************/
+
+#include <goto-programs/goto_function.h>
+#include <testing-utils/catch.hpp>
+#include <util/arith_tools.h>
+
+SCENARIO(
+  "Validation of well-formed goto codes",
+  "[core][goto-programs][validate]")
+{
+  GIVEN("A program with one assertion")
+  {
+    symbol_tablet symbol_table;
+    const typet type1 = signedbv_typet(32);
+    symbolt symbol;
+    irep_idt symbol_name = "a";
+    symbol.name = symbol_name;
+    symbol_exprt varx(symbol_name, type1);
+    exprt val10 = from_integer(10, type1);
+    binary_relation_exprt x_le_10(varx, ID_le, val10);
+
+    goto_functiont goto_function;
+    auto &instructions = goto_function.body.instructions;
+    instructions.emplace_back(goto_program_instruction_typet::ASSERT);
+    instructions.back().make_assertion(x_le_10);
+
+    instructions.emplace_back(goto_program_instruction_typet::GOTO);
+    instructions.back().make_goto(instructions.begin());
+
+    symbol.type = type1;
+    symbol_table.insert(symbol);
+    namespacet ns(symbol_table);
+
+    WHEN("Target is a target")
+    {
+      instructions.front().target_number = 1;
+      THEN("The consistency check succeeds")
+      {
+        goto_function.body.validate(ns, validation_modet::INVARIANT);
+        REQUIRE(true);
+      }
+    }
+
+    WHEN("Target is not a target")
+    {
+      THEN("The consistency check fails")
+      {
+        bool caught = false;
+        try
+        {
+          goto_function.body.validate(ns, validation_modet::EXCEPTION);
+        }
+        catch(incorrect_goto_program_exceptiont &e)
+        {
+          caught = true;
+        }
+        REQUIRE(caught);
+      }
+    }
+  }
+}

--- a/unit/goto-programs/goto_program_goto_target.cpp
+++ b/unit/goto-programs/goto_program_goto_target.cpp
@@ -42,7 +42,7 @@ SCENARIO(
       instructions.front().target_number = 1;
       THEN("The consistency check succeeds")
       {
-        goto_function.body.validate(ns, validation_modet::INVARIANT);
+        goto_function.body.validate(symbol_table, validation_modet::INVARIANT);
         REQUIRE(true);
       }
     }
@@ -54,7 +54,8 @@ SCENARIO(
         bool caught = false;
         try
         {
-          goto_function.body.validate(ns, validation_modet::EXCEPTION);
+          goto_function.body.validate(
+            symbol_table, validation_modet::EXCEPTION);
         }
         catch(incorrect_goto_program_exceptiont &e)
         {


### PR DESCRIPTION
Two simple tests are added: 1) targets are empty, 2) the guard evaluates to a
Boolean. The second test is a case-analysis of the expression id.